### PR TITLE
Fix disablecontrols.py AssociationStatus

### DIFF
--- a/src/disablecontrols.py
+++ b/src/disablecontrols.py
@@ -75,7 +75,7 @@ def control_state(securityhub_client):
                     {
                         'StandardsArn': SECURITY_STANDARD,
                         'SecurityControlId': control_id,
-                        'AssociationStatus': 'ENABLED',
+                        'AssociationStatus': 'DISABLED',
                         'UpdatedReason': 'multiaccountscript'
                     },
                 ]


### PR DESCRIPTION
The AssociationStatus is set to ENABLED.
This commit resolves the issue.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
